### PR TITLE
fix: only parse tags starting at beginning of newlines

### DIFF
--- a/pkg/commands/parse/parse_test.go
+++ b/pkg/commands/parse/parse_test.go
@@ -394,7 +394,7 @@ TAG_1=my-tag-value3
 				t.Errorf("Platform calls not as expected; (-got,+want): %s", diff)
 			}
 
-			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.expStdout); !strings.Contains(got, want) {
+			if got, want := strings.TrimSpace(stdout.String()), strings.TrimSpace(tc.expStdout); got != want {
 				t.Errorf("expected stdout\n\n%s\n\nto contain\n\n%s\n\n", got, want)
 			}
 			if got, want := strings.TrimSpace(stderr.String()), strings.TrimSpace(tc.expStderr); !strings.Contains(got, want) {

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -55,7 +55,7 @@ var (
 		return allowed
 	}()
 	// tagPattern is a Regex pattern used to parse the tags from a multiline string.
-	tagPattern = regexp.MustCompile(`([A-Za-z0-9_]*)=([^\n\r]*)`)
+	tagPattern = regexp.MustCompile(`(?m)^([A-Za-z0-9_]*)=([^\n\r]*)`)
 )
 
 type TagParser struct {


### PR DESCRIPTION
Fixes a bug where any TAG_NAME=TAG_VALUE is parsed from anywhere in the line. Now only lines starting with the TAG_NAME= will be parsed.