### PR TITLE
feat: support explicitly setting tags

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -65,7 +65,7 @@ jobs:
             -format=json \
             -pretty \
             -array-tags=SOME_ARRAY_TAG_ON_A_PR \
-            -string-tags=SOME_OTHER_TAG_ON_A_PR,SOME_TAG_ON_A_PR \
+            -string-tags=SOME_OTHER_TAG_ON_A_PR,SOME_TAG_ON_A_PR,DO_NOT_MODIFY \
             -github-pull-request-number=12)"
           diff <(echo "$GOT") <(echo "$WANT")
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -63,7 +63,6 @@ jobs:
           GOT="$(go run ./cmd/tagrep parse \
             -type=request \
             -format=json \
-            -duplicate-key-strategy=array \
             -pretty \
             -array-tags=SOME_ARRAY_TAG_ON_A_PR \
             -string-tags=SOME_OTHER_TAG_ON_A_PR,SOME_TAG_ON_A_PR \
@@ -91,7 +90,6 @@ jobs:
             -type=issue \
             -format=json \
             -pretty \
-            -duplicate-key-strategy=array \
             -array-tags=MY_ARRAY \
             -output-all \
             -github-issue-number=11)"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -65,7 +65,8 @@ jobs:
             -format=json \
             -duplicate-key-strategy=array \
             -pretty \
-            -array-fields=SOME_ARRAY_TAG_ON_A_PR \
+            -array-tags=SOME_ARRAY_TAG_ON_A_PR \
+            -string-tags=SOME_OTHER_TAG_ON_A_PR,SOME_TAG_ON_A_PR \
             -github-pull-request-number=12)"
           diff <(echo "$GOT") <(echo "$WANT")
 
@@ -91,6 +92,7 @@ jobs:
             -format=json \
             -pretty \
             -duplicate-key-strategy=array \
-            -array-fields=MY_ARRAY \
+            -array-tags=MY_ARRAY \
+            -output-all \
             -github-issue-number=11)"
           diff <(echo "$GOT") <(echo "$WANT")

--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ tagrep parse -type=request -format=json
 
 #### CLI Flags
 
-| flag                      | required | possible values      | description                                                                                                                                                           |
-|---------------------------|----------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-type`                   | x        | `issue`, `request`   | Whether to fetch a github/gitlab issue or pull/merge request.                                                                                                         |
-| `-format`                 |          | `json`, `raw`        | The format to output as. `json` will output as a single json object. `raw` will output as separate rows parsable into env variables.                                  |
-| `-duplicate-key-strategy` |          | `take-last`, `array` | How to handle multiple lines with the same tag key. `array` will concatenate the values indicated by `-array-fields` into a json array (even if the format is `raw`). |
-| `-array-fields`           |          | {{any}}              | The fields that should be treated as an array. To be combined with `-duplicate-key-strategy=array`                                                                    |
+| flag           | required | possible values    | description                                                                                                                                                    |
+|----------------|----------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-type`        | x        | `issue`, `request` | Whether to fetch a github/gitlab issue or pull/merge request.                                                                                                  |
+| `-format`      |          | `json`, `raw`      | The format to output as. `json` will output as a single json object. `raw` will output as separate rows parsable into env variables.                           |
+| `-array-tags`  |          | {{any}}            | The tags that should be treated as an array.                                                                                                                   |
+| `-string-tags` |          | {{any}}            | The tags that should be treated as a string.                                                                                                                   |
+| `-bool-tags`   |          | {{any}}            | The tags that should be treated as a bool.                                                                                                                     |
+| `-output-all`  |          | true,false         | Whether to output all found tags or just those in `-array-tags`, `-string-tags`, and `-bool-tags`. Defaults to false (just those in the `-{type}-tags` flags). |
 
 #### GitHub Optional Flags
 

--- a/pkg/commands/parse/parse.go
+++ b/pkg/commands/parse/parse.go
@@ -85,10 +85,10 @@ Usage: {{ COMMAND }} [options]
 `
 }
 
-func (c *ParseCommand) Flags() *cli.FlagSet {
+func (c *ParseCommand) FlagsContext(ctx context.Context) *cli.FlagSet {
 	set := c.NewFlagSet()
 
-	c.platformConfig.RegisterFlags(set)
+	c.platformConfig.RegisterFlagsContext(ctx, set)
 	c.tagsConfig.RegisterFlags(set)
 
 	f := set.NewSection("TAGREP OPTIONS")
@@ -119,7 +119,7 @@ func (c *ParseCommand) Flags() *cli.FlagSet {
 func (c *ParseCommand) Run(ctx context.Context, args []string) error {
 	metricswrap.WriteMetric(ctx, "command_request", 1)
 
-	f := c.Flags()
+	f := c.FlagsContext(ctx)
 	if err := f.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -33,7 +34,7 @@ type Config struct {
 	GitLab gitLabConfig
 }
 
-func (c *Config) RegisterFlags(set *cli.FlagSet) {
+func (c *Config) RegisterFlagsContext(ctx context.Context, set *cli.FlagSet) {
 	f := set.NewSection("PLATFORM OPTIONS")
 	// Type value is loaded in the following order:
 	//
@@ -51,8 +52,8 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 	})
 
 	// leave last to put help under platform options
-	c.GitHub.RegisterFlags(set)
-	c.GitLab.RegisterFlags(set)
+	c.GitHub.RegisterFlagsContext(ctx, set)
+	c.GitLab.RegisterFlagsContext(ctx, set)
 
 	set.AfterParse(func(merr error) error {
 		c.Type = strings.ToLower(strings.TrimSpace(c.Type))

--- a/pkg/platform/github.go
+++ b/pkg/platform/github.go
@@ -108,7 +108,7 @@ func (c *gitHubConfigDefaults) Load(ctx context.Context, githubContext *githubac
 			c.PullRequestNumber = event.GetNumber()
 			c.PullRequestBody = event.GetPullRequest().GetBody()
 		} else {
-			logging.FromContext(ctx).Warn("parsing pull_request event context failed", "error", err)
+			logging.FromContext(ctx).WarnContext(ctx, "parsing pull_request event context failed", "error", err)
 		}
 	case "pull_request_target":
 		var event github.PullRequestTargetEvent
@@ -116,7 +116,7 @@ func (c *gitHubConfigDefaults) Load(ctx context.Context, githubContext *githubac
 			c.PullRequestNumber = event.GetNumber()
 			c.PullRequestBody = event.GetPullRequest().GetBody()
 		} else {
-			logging.FromContext(ctx).Warn("parsing pull_request_target event context failed", "error", err)
+			logging.FromContext(ctx).WarnContext(ctx, "parsing pull_request_target event context failed", "error", err)
 		}
 	case "pull_request_review":
 		var event github.PullRequestReviewEvent
@@ -124,7 +124,7 @@ func (c *gitHubConfigDefaults) Load(ctx context.Context, githubContext *githubac
 			c.PullRequestNumber = event.GetPullRequest().GetNumber()
 			c.PullRequestBody = event.GetPullRequest().GetBody()
 		} else {
-			logging.FromContext(ctx).Warn("parsing pull_request_review event context failed", "error", err)
+			logging.FromContext(ctx).WarnContext(ctx, "parsing pull_request_review event context failed", "error", err)
 		}
 	case "merge_group":
 		var event github.MergeGroupEvent
@@ -134,16 +134,16 @@ func (c *gitHubConfigDefaults) Load(ctx context.Context, githubContext *githubac
 				if v, err := strconv.Atoi(matches[1]); err == nil {
 					c.PullRequestNumber = v
 				} else {
-					logging.FromContext(ctx).Warn("parsing merge_group head_ref for pull request number failed",
+					logging.FromContext(ctx).WarnContext(ctx, "parsing merge_group head_ref for pull request number failed",
 						"head_ref", event.GetMergeGroup().GetHeadRef(),
 						"error", err)
 				}
 			} else {
-				logging.FromContext(ctx).Warn("parsing merge_group head_ref for pull request number failed", "head_ref", event.GetMergeGroup().GetHeadRef())
+				logging.FromContext(ctx).WarnContext(ctx, "parsing merge_group head_ref for pull request number failed", "head_ref", event.GetMergeGroup().GetHeadRef())
 			}
 			// Pull request body is not available on the merge_group event.
 		} else {
-			logging.FromContext(ctx).Warn("parsing merge_group event context failed", "error", err)
+			logging.FromContext(ctx).WarnContext(ctx, "parsing merge_group event context failed", "error", err)
 		}
 	case "issues":
 		var event github.IssuesEvent
@@ -151,12 +151,12 @@ func (c *gitHubConfigDefaults) Load(ctx context.Context, githubContext *githubac
 			c.IssueNumber = event.GetIssue().GetNumber()
 			c.IssueBody = event.GetIssue().GetBody()
 		} else {
-			logging.FromContext(ctx).Warn("parsing issues event context failed", "error", err)
+			logging.FromContext(ctx).WarnContext(ctx, "parsing issues event context failed", "error", err)
 		}
 	case "":
-		logging.FromContext(ctx).Info("found no github context event, if you meant to run this in github, something has gone wrong.")
+		logging.FromContext(ctx).InfoContext(ctx, "found no github context event, if you meant to run this in github, something has gone wrong.")
 	default:
-		logging.FromContext(ctx).Warn("unhandled tagrep github event context type", "context_event_name", githubContext.EventName)
+		logging.FromContext(ctx).WarnContext(ctx, "unhandled tagrep github event context type", "context_event_name", githubContext.EventName)
 	}
 }
 

--- a/pkg/platform/github_test.go
+++ b/pkg/platform/github_test.go
@@ -165,7 +165,6 @@ func TestGitHubConfigDefaults_Load(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/platform/github_test.go
+++ b/pkg/platform/github_test.go
@@ -19,10 +19,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-githubactions"
+
+	"github.com/abcxyz/pkg/logging"
 )
 
 func TestGitHubConfigDefaults_Load(t *testing.T) {
 	t.Parallel()
+
+	ctx := logging.WithLogger(t.Context(), logging.TestLogger(t))
 
 	cases := []struct {
 		name          string
@@ -161,11 +165,12 @@ func TestGitHubConfigDefaults_Load(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			c := &gitHubConfigDefaults{}
-			c.Load(tc.githubContext)
+			c.Load(ctx, tc.githubContext)
 
 			if diff := cmp.Diff(c, tc.exp); diff != "" {
 				t.Errorf("GitHubConfigDefaults not as expected; (-got,+want): %s", diff)

--- a/pkg/platform/gitlab.go
+++ b/pkg/platform/gitlab.go
@@ -98,7 +98,7 @@ func (c *gitLabPredefinedConfig) Load() {
 	}
 }
 
-func (c *gitLabConfig) RegisterFlags(set *cli.FlagSet) {
+func (c *gitLabConfig) RegisterFlagsContext(ctx context.Context, set *cli.FlagSet) {
 	f := set.NewSection("GITLAB OPTIONS")
 
 	cfgDefaults := &gitLabPredefinedConfig{}

--- a/pkg/tags/config.go
+++ b/pkg/tags/config.go
@@ -27,25 +27,17 @@ import (
 
 // Config is the configuration needed to parse tags.
 type Config struct {
-	DuplicateKeyStrategy string
-	Format               string
-	ArrayFields          []string
-	PrettyPrint          bool
+	Format      string
+	ArrayTags   []string
+	StringTags  []string
+	BoolTags    []string
+	OutputAll   bool
+	PrettyPrint bool
 }
 
 func (c *Config) RegisterFlags(set *cli.FlagSet) {
 	f := set.NewSection("TAG OPTIONS")
 
-	f.StringVar(&cli.StringVar{
-		Name:    "duplicate-key-strategy",
-		Target:  &c.DuplicateKeyStrategy,
-		Example: "array",
-		Default: DuplicateKeyStrategyArray,
-		Usage:   fmt.Sprintf("How to handle lines with duplicate tag keys. Allowed values are %q. Defaults to concatenating all tag values into an array.", allowedStrategies),
-		Predict: complete.PredictFunc(func(prefix string) []string {
-			return allowedStrategies
-		}),
-	})
 	f.StringVar(&cli.StringVar{
 		Name:    "format",
 		Target:  &c.Format,
@@ -57,11 +49,32 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		}),
 	})
 	f.StringSliceVar(&cli.StringSliceVar{
-		Name:    "array-fields",
-		Target:  &c.ArrayFields,
+		Name:    "array-tags",
+		Target:  &c.ArrayTags,
 		Example: "TAG_1",
 		Default: []string{},
-		Usage:   "Fields to format as an array. e.g. treat TAG_1 as an array.",
+		Usage:   "Tags to format as an array. e.g. treat TAG_1 as an array.",
+	})
+	f.StringSliceVar(&cli.StringSliceVar{
+		Name:    "string-tags",
+		Target:  &c.StringTags,
+		Example: "TAG_1",
+		Default: []string{},
+		Usage:   "Tags to format as a string. e.g. treat TAG_1 as a string.",
+	})
+	f.StringSliceVar(&cli.StringSliceVar{
+		Name:    "bool-tags",
+		Target:  &c.BoolTags,
+		Example: "TAG_1",
+		Default: []string{},
+		Usage:   "Tags to format as a bool. e.g. treat TAG_1 as a bool.",
+	})
+	f.BoolVar(&cli.BoolVar{
+		Name:    "output-all",
+		Target:  &c.OutputAll,
+		Example: "true",
+		Default: false,
+		Usage:   "Whether to print out all tags present in the resource or only those explicity set in -array-tags, -string-tags, -bool-tags.",
 	})
 	f.BoolVar(&cli.BoolVar{
 		Name:    "pretty",
@@ -72,12 +85,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 	})
 
 	set.AfterParse(func(merr error) error {
-		c.DuplicateKeyStrategy = strings.ToLower(strings.TrimSpace(c.DuplicateKeyStrategy))
 		c.Format = strings.ToLower(strings.TrimSpace(c.Format))
-
-		if !slices.Contains(allowedStrategies, c.DuplicateKeyStrategy) {
-			merr = errors.Join(merr, fmt.Errorf("unsupported value for duplicate key strategy flag: %s", c.DuplicateKeyStrategy))
-		}
 
 		if !slices.Contains(allowedFormats, c.Format) {
 			merr = errors.Join(merr, fmt.Errorf("unsupported value for format flag: %s", c.Format))

--- a/pkg/tags/config.go
+++ b/pkg/tags/config.go
@@ -74,7 +74,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		Target:  &c.OutputAll,
 		Example: "true",
 		Default: false,
-		Usage:   "Whether to print out all tags present in the resource or only those explicity set in -array-tags, -string-tags, -bool-tags.",
+		Usage:   "Whether to print out all tags present in the resource or only those explicitly set in -array-tags, -string-tags, -bool-tags.",
 	})
 	f.BoolVar(&cli.BoolVar{
 		Name:    "pretty",

--- a/pkg/tags/config.go
+++ b/pkg/tags/config.go
@@ -43,7 +43,7 @@ func (c *Config) RegisterFlags(set *cli.FlagSet) {
 		Target:  &c.Format,
 		Example: "json",
 		Default: FormatRaw,
-		Usage:   fmt.Sprintf("Format for the output. Allowed values are %q. Defaults to raw (outputs the deduplicated tags as they were in the PR for easy parsing into bash env variables). If -duplicate-key-strategy=array then only those keys in -array-fields will be concatenated into separate JSON arrays.", allowedFormats),
+		Usage:   fmt.Sprintf("Format for the output. Allowed values are %q. Defaults to raw (outputs the deduplicated tags as they were in the PR for easy parsing into bash env variables).", allowedFormats),
 		Predict: complete.PredictFunc(func(prefix string) []string {
 			return allowedFormats
 		}),

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -152,13 +152,9 @@ func parseBoolValue(v string) (bool, error) {
 	//   1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
 	// https://pkg.go.dev/strconv#ParseBool
 	switch vtl {
-	case "yes":
+	case "yes", "y":
 		return true, nil
-	case "y":
-		return true, nil
-	case "no":
-		return false, nil
-	case "n":
+	case "no", "n":
 		return false, nil
 	default:
 		b, err := strconv.ParseBool(vtl)

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -124,7 +124,7 @@ func (p *TagParser) processTagValues(ctx context.Context, key string, ts []strin
 	if slices.Contains(p.cfg.ArrayTags, key) {
 		return ts, nil
 	}
-	if len(ts) > 0 {
+	if len(ts) > 1 {
 		logging.FromContext(ctx).WarnContext(ctx, "encountered duplicate keys that are not in -array-tags. Defaulting to taking the last value.",
 			"key", key,
 			"array_tags", p.cfg.ArrayTags,


### PR DESCRIPTION
This change makes it so that only the tags that are explicitly set with `-array-tags`, `-string-tags`, or `-bool-tags` are outputted unless you set `-output-all`. Also removes the `-duplicate-key-strategy` flag as this can be inferred based on the presence of other flags